### PR TITLE
Fix monitor interval always set default value

### DIFF
--- a/keel_telegram_bot/config.py
+++ b/keel_telegram_bot/config.py
@@ -143,7 +143,7 @@ class Config(ConfigBase):
         description="Interval to check for new pending approvals",
         key_path=[
             NODE_MAIN,
-            "monitor"
+            "monitor",
             "interval"
         ],
         default="1m",


### PR DESCRIPTION
Hi 

I try to change monitor interval, but it's alway set default value 1min.
I found the program lose a comma. 